### PR TITLE
fix: offset signup page from header

### DIFF
--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -44,7 +44,7 @@ export default function SignUpPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center pt-24 pb-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         {/* Header */}
         <div className="text-center">


### PR DESCRIPTION
## Summary
- add top padding to signup page container so logo isn't covered by fixed header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type...)*

------
https://chatgpt.com/codex/tasks/task_e_68b20664c4f4832abb346a0346c32f7e