### PR TITLE
refactor: improve auth form flows

### DIFF
--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -10,18 +10,19 @@ export default function ForgotPasswordPage() {
   const [emailSent, setEmailSent] = useState(false);
   const { resetPassword } = useAuth();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError('');
+    try {
+      const { error: authError } = await resetPassword(email);
 
-    const { error: authError } = await resetPassword(email);
-    
-    if (authError) {
-      setError(authError.message);
-      setLoading(false);
-    } else {
-      setEmailSent(true);
+      if (authError) {
+        setError(authError.message);
+      } else {
+        setEmailSent(true);
+      }
+    } finally {
       setLoading(false);
     }
   };

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -23,7 +23,7 @@ export default function ResetPasswordPage() {
     }
   }, [authLoading, session, navigate]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError('');
@@ -40,19 +40,21 @@ export default function ResetPasswordPage() {
       return;
     }
 
-    const { error: authError } = await updatePassword(formData.password);
-    
-    if (authError) {
-      setError(authError.message);
+    try {
+      const { error: authError } = await updatePassword(formData.password);
+
+      if (authError) {
+        setError(authError.message);
+      } else {
+        setSuccess(true);
+
+        // Redirect to sign in after 3 seconds
+        setTimeout(() => {
+          navigate('/signin');
+        }, 3000);
+      }
+    } finally {
       setLoading(false);
-    } else {
-      setSuccess(true);
-      setLoading(false);
-      
-      // Redirect to sign in after 3 seconds
-      setTimeout(() => {
-        navigate('/signin');
-      }, 3000);
     }
   };
 
@@ -153,11 +155,12 @@ export default function ResetPasswordPage() {
                   className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 font-sans"
                   placeholder="Enter new password"
                 />
-                <button
-                  type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  onClick={() => setShowPassword(!showPassword)}
-                >
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
                   {showPassword ? (
                     <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />
                   ) : (
@@ -208,11 +211,12 @@ export default function ResetPasswordPage() {
                   className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 font-sans"
                   placeholder="Confirm new password"
                 />
-                <button
-                  type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                >
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                    aria-label={showConfirmPassword ? 'Hide password' : 'Show password'}
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
                   {showConfirmPassword ? (
                     <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />
                   ) : (

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -12,18 +12,20 @@ export default function SignInPage() {
   const { signIn } = useAuth();
   const navigate = useNavigate();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError('');
+    try {
+      const { error: authError } = await signIn(email, password);
 
-    const { error: authError } = await signIn(email, password);
-    
-    if (authError) {
-      setError(authError.message);
+      if (authError) {
+        setError(authError.message);
+      } else {
+        navigate('/dashboard');
+      }
+    } finally {
       setLoading(false);
-    } else {
-      navigate('/dashboard');
     }
   };
 
@@ -99,6 +101,7 @@ export default function SignInPage() {
                 <button
                   type="button"
                   className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (

--- a/src/pages/SignUpPage.tsx
+++ b/src/pages/SignUpPage.tsx
@@ -15,7 +15,7 @@ export default function SignUpPage() {
     confirmPassword: ''
   });
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError('');
@@ -26,13 +26,16 @@ export default function SignUpPage() {
       return;
     }
 
-    const { error: authError } = await signUp(formData.email, formData.password);
-    
-    if (authError) {
-      setError(authError.message);
+    try {
+      const { error: authError } = await signUp(formData.email, formData.password);
+
+      if (authError) {
+        setError(authError.message);
+      } else {
+        navigate('/get-started');
+      }
+    } finally {
       setLoading(false);
-    } else {
-      navigate('/get-started');
     }
   };
 
@@ -114,11 +117,12 @@ export default function SignUpPage() {
                   className="block w-full pl-10 pr-10 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 font-sans"
                   placeholder="Create a password"
                 />
-                <button
-                  type="button"
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                  onClick={() => setShowPassword(!showPassword)}
-                >
+                  <button
+                    type="button"
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
                   {showPassword ? (
                     <EyeOff className="h-5 w-5 text-gray-400 hover:text-gray-600" />
                   ) : (


### PR DESCRIPTION
## Summary
- ensure auth forms always reset loading state on submit
- add accessibility labels to password visibility toggles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b21887aa04832a9dc6296609e524a1