### PR TITLE
Persist checklist creation progress across tab switches

### DIFF
--- a/src/hooks/useSessionProgress.ts
+++ b/src/hooks/useSessionProgress.ts
@@ -37,11 +37,10 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     }
 
     return () => {
-      cleanup();
+      void cleanup();
     };
   }, [checklistId, sessionToken]);
-
-  const cleanup = () => {
+  const cleanup = async () => {
     if (activityInterval.current) {
       clearInterval(activityInterval.current);
     }
@@ -52,10 +51,10 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     saveTimeouts.current.forEach(timeout => clearTimeout(timeout));
     saveTimeouts.current.clear();
     // Process any pending saves before cleanup
-    processPendingSaves();
+    await processPendingSaves();
     // Mark session as inactive when leaving
     if (session) {
-      updateSessionActivity(false);
+      await updateSessionActivity(false);
     }
   };
 
@@ -97,10 +96,10 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
   const setupBeforeUnloadHandler = () => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       // Save any pending changes before user leaves
-      processPendingSaves();
-      
+      void processPendingSaves();
+
       // If there are unsaved changes, warn the user
-      if (pendingSaves.current.size > 0) {
+      if (pendingSaves.current.size > 0 || saveQueue.current.length > 0) {
         e.preventDefault();
         e.returnValue = 'You have unsaved changes. Are you sure you want to leave?';
         return e.returnValue;
@@ -118,7 +117,7 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
         // Page is being hidden, save any pending changes
-        processPendingSaves();
+        void processPendingSaves();
       } else if (document.visibilityState === 'visible') {
         // Page is visible again, resume normal operation
         if (session) {
@@ -136,19 +135,17 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
 
   const processPendingSaves = async () => {
     // Process all pending saves immediately
-    const saves = Array.from(pendingSaves.current.entries());
-    pendingSaves.current.clear();
-    
-    for (const [stepId, notes] of saves) {
+    for (const [stepId, notes] of Array.from(pendingSaves.current.entries())) {
       try {
         await performSave(stepId, notes);
+        pendingSaves.current.delete(stepId);
       } catch (err) {
         console.error('Failed to save pending change:', err);
-        // Add back to queue for retry
+        // Add to queue for retry
         saveQueue.current.push({ stepId, notes, timestamp: Date.now() });
       }
     }
-    
+
     // Process any queued saves
     await processQueuedSaves();
   };
@@ -220,10 +217,13 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     }
   };
 
+  const markPendingSave = (stepId: string, notes: string = '') => {
+    pendingSaves.current.set(stepId, notes);
+  };
+
   const saveStepProgress = useCallback(async (stepId: string, notes: string = '') => {
     if (!session) return false;
 
-    // Save immediately without debouncing
     return performSave(stepId, notes);
   }, [session]);
 
@@ -234,9 +234,6 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     setSaving(true);
     
     try {
-      // Remove from pending saves since we're processing it
-      pendingSaves.current.delete(stepId);
-      
       const { error } = await supabase
         .from('session_progress')
         .upsert({
@@ -276,6 +273,7 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
       if (typeof window !== 'undefined') {
         localStorage.removeItem(`progress-${checklistId}-${stepId}`);
       }
+      pendingSaves.current.delete(stepId);
 
       return true;
     } catch (err) {
@@ -479,6 +477,7 @@ export function useSessionProgress({ checklistId, sessionToken }: UseSessionProg
     otherActiveUsers,
     showConcurrentEditNotification,
     createSession,
+    markPendingSave,
     saveStepProgress,
     removeStepProgress,
     completeSession,

--- a/src/pages/CreateChecklistPage.tsx
+++ b/src/pages/CreateChecklistPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { checklistTemplates, ChecklistTemplate } from '../data/checklistTemplates';
 import { useAuth } from '../contexts/AuthContext';
@@ -7,7 +7,7 @@ import { useChecklists } from '../hooks/useChecklists';
 import PaymentBanner from '../components/PaymentBanner';
 import TrialBanner from '../components/TrialBanner';
 import { CreateChecklistData } from '../types/checklist';
-import { 
+import {
   ArrowRight, 
   ArrowLeft, 
   CheckCircle, 
@@ -44,6 +44,8 @@ const STEP_TYPE_OPTIONS = [
   { value: 'secure_text', label: 'Secure Text', description: 'Sensitive information' }
 ];
 
+const DRAFT_STORAGE_KEY = 'create-checklist-draft';
+
 export default function CreateChecklistPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -66,6 +68,8 @@ export default function CreateChecklistPage() {
 
   const [steps, setSteps] = useState<StepData[]>([]);
 
+  const hasLoadedDraft = useRef(false);
+
   // Load from URL params if available
   useEffect(() => {
     const templateId = searchParams.get('template');
@@ -77,6 +81,52 @@ export default function CreateChecklistPage() {
       }
     }
   }, [searchParams]);
+
+  // Load any saved draft
+  useEffect(() => {
+    const stored = localStorage.getItem(DRAFT_STORAGE_KEY);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (parsed.formData) setFormData(parsed.formData);
+        if (parsed.steps) setSteps(parsed.steps);
+        if (parsed.currentStep) setCurrentStep(parsed.currentStep);
+        if (typeof parsed.editingStepIndex === 'number') setEditingStepIndex(parsed.editingStepIndex);
+        if (parsed.templateId) {
+          const template = checklistTemplates.find(t => t.id === parsed.templateId);
+          if (template) setSelectedTemplate(template);
+        }
+      } catch {}
+    }
+    hasLoadedDraft.current = true;
+  }, []);
+
+  const saveDraft = useCallback(() => {
+    const templateId = selectedTemplate?.id ?? null;
+    localStorage.setItem(
+      DRAFT_STORAGE_KEY,
+      JSON.stringify({ formData, steps, currentStep, editingStepIndex, templateId })
+    );
+  }, [formData, steps, currentStep, editingStepIndex, selectedTemplate]);
+
+  useEffect(() => {
+    if (hasLoadedDraft.current) {
+      saveDraft();
+    }
+  }, [saveDraft]);
+
+  useEffect(() => {
+    const handleBeforeUnload = () => saveDraft();
+    const handleVisibilityChange = () => {
+      if (document.hidden) saveDraft();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [saveDraft]);
 
   const handleTemplateSelect = (template: ChecklistTemplate) => {
     setSelectedTemplate(template);
@@ -165,6 +215,7 @@ export default function CreateChecklistPage() {
     try {
       const success = await createChecklist({ ...formData, steps });
       if (success) {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
         navigate('/checklists');
       }
     } finally {

--- a/src/pages/PublicChecklistPage.tsx
+++ b/src/pages/PublicChecklistPage.tsx
@@ -86,9 +86,10 @@ export default function PublicChecklistPage() {
     getCompletionPercentage,
     updateSessionInfo,
     getSecureText,
-  } = useSessionProgress({ 
-    checklistId: checklistId || '', 
-    sessionToken 
+    markPendingSave,
+  } = useSessionProgress({
+    checklistId: checklistId || '',
+    sessionToken
   });
 
   useEffect(() => {
@@ -134,9 +135,12 @@ export default function PublicChecklistPage() {
     const initialValues: Record<string, string> = {};
     progress.forEach(p => {
       initialValues[p.step_id] = p.notes;
+      if (checklistId && typeof window !== 'undefined') {
+        localStorage.removeItem(`progress-${checklistId}-${p.step_id}`);
+      }
     });
     setLocalStepValues(prev => ({ ...initialValues, ...prev }));
-  }, [progress]);
+  }, [progress, checklistId]);
 
   const fetchChecklistData = async () => {
     if (!checklistId) return;
@@ -263,6 +267,9 @@ export default function PublicChecklistPage() {
       }
     }
 
+    // Mark this change as pending for beforeunload protection
+    markPendingSave(stepId, typeof value === 'string' ? value : '');
+
     // Clear existing timeout for this step
     const existingTimeout = inputTimeouts.current.get(stepId);
     if (existingTimeout) {
@@ -288,7 +295,7 @@ export default function PublicChecklistPage() {
     }, 800);
 
     inputTimeouts.current.set(stepId, timeout);
-  }, [checklistId, saveStepProgress, removeStepProgress]);
+  }, [checklistId, saveStepProgress, removeStepProgress, markPendingSave]);
 
   // Cleanup timeouts on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Ensure checklist drafts load before auto-saving to localStorage
- Clear stale step progress and mark edits as pending in public checklists
- Flush and retry pending saves on unload or hidden tabs, removing local data after successful saves

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba26673cdc832aab31756a44a15259