### PR TITLE
Wait for subscription loading before redirecting

### DIFF
--- a/src/pages/BrandingPage.tsx
+++ b/src/pages/BrandingPage.tsx
@@ -37,10 +37,10 @@ const PRESET_COLORS = [
 
 export default function BrandingPage() {
   const { user } = useAuth();
-  const { getAccessStatus } = useSubscription();
+  const { loading, getAccessStatus } = useSubscription();
   const navigate = useNavigate();
   const [branding, setBranding] = useState<UserBranding | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [brandingLoading, setBrandingLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -57,10 +57,10 @@ export default function BrandingPage() {
 
   // Redirect to dashboard if no active subscription
   useEffect(() => {
-    if (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted) {
+    if (!loading && (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted)) {
       navigate('/dashboard');
     }
-  }, [accessStatus, navigate]);
+  }, [loading, accessStatus, navigate]);
 
   useEffect(() => {
     fetchBranding();
@@ -89,11 +89,11 @@ export default function BrandingPage() {
         setBusinessName(data.business_name || '');
       }
       
-      setLoading(false);
+      setBrandingLoading(false);
     } catch (error) {
       console.error('Error fetching branding:', error);
       setError('Failed to load branding settings');
-      setLoading(false);
+      setBrandingLoading(false);
     }
   };
 
@@ -186,7 +186,7 @@ export default function BrandingPage() {
     }
   };
 
-  if (loading) {
+  if (brandingLoading) {
     return (
       <div className="pt-20 min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-emerald-600"></div>

--- a/src/pages/ChecklistsPage.tsx
+++ b/src/pages/ChecklistsPage.tsx
@@ -18,8 +18,8 @@ import {
 
 export default function ChecklistsPage() {
   const { user } = useAuth();
-  const { subscription, getAccessStatus } = useSubscription();
-  const { checklists, loading, error, deleteChecklist } = useChecklists();
+  const { loading, getAccessStatus } = useSubscription();
+  const { checklists, loading: checklistsLoading, error, deleteChecklist } = useChecklists();
   const { createPendingSubmission } = useCustomerSessions();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -29,10 +29,10 @@ export default function ChecklistsPage() {
 
   // Redirect to dashboard if no active subscription
   useEffect(() => {
-    if (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted) {
+    if (!loading && (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted)) {
       navigate('/dashboard');
     }
-  }, [accessStatus, navigate]);
+  }, [loading, accessStatus, navigate]);
 
   const handleCreateChecklist = () => {
     navigate('/checklists/create');
@@ -73,7 +73,7 @@ export default function ChecklistsPage() {
     navigate('/submissions');
   };
 
-  if (loading) {
+  if (checklistsLoading) {
     return (
       <div className="pt-20 min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">

--- a/src/pages/CreateChecklistPage.tsx
+++ b/src/pages/CreateChecklistPage.tsx
@@ -7,7 +7,7 @@ import { useChecklists } from '../hooks/useChecklists';
 import PaymentBanner from '../components/PaymentBanner';
 import TrialBanner from '../components/TrialBanner';
 import { CreateChecklistData } from '../types/checklist';
-import { 
+import {
   ArrowRight, 
   ArrowLeft, 
   CheckCircle, 
@@ -50,13 +50,13 @@ export default function CreateChecklistPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { user } = useAuth();
-  const { subscription, getAccessStatus } = useSubscription();
+  const { loading, getAccessStatus } = useSubscription();
   const { createChecklist } = useChecklists();
   const accessStatus = getAccessStatus();
   
   const [currentStep, setCurrentStep] = useState<'welcome' | 'choose' | 'customize' | 'launch'>('welcome');
   const [selectedTemplate, setSelectedTemplate] = useState<ChecklistTemplate | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [editingStepIndex, setEditingStepIndex] = useState<number | null>(null);
   
   const [formData, setFormData] = useState<CreateChecklistData>({
@@ -70,10 +70,10 @@ export default function CreateChecklistPage() {
 
   // Redirect to dashboard if no active subscription
   useEffect(() => {
-    if (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted) {
+    if (!loading && (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted)) {
       navigate('/dashboard');
     }
-  }, [accessStatus, navigate]);
+  }, [loading, accessStatus, navigate]);
 
   // Load from URL params if available
   useEffect(() => {
@@ -246,7 +246,7 @@ export default function CreateChecklistPage() {
       return;
     }
 
-    setLoading(true);
+    setSaving(true);
     try {
       const success = await createChecklist({ ...formData, steps });
       if (success) {
@@ -254,7 +254,7 @@ export default function CreateChecklistPage() {
         navigate('/checklists');
       }
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   };
 
@@ -776,10 +776,10 @@ export default function CreateChecklistPage() {
       <div className="space-y-4">
         <button
           onClick={handleSave}
-          disabled={loading || !formData.title.trim() || steps.length === 0}
+          disabled={saving || !formData.title.trim() || steps.length === 0}
           className="bg-emerald-500 hover:bg-emerald-600 text-white px-8 py-4 rounded-lg font-semibold text-lg transition-colors flex items-center mx-auto disabled:opacity-50 font-sans"
         >
-          {loading ? (
+          {saving ? (
             <>
               <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
               Creating Checklist...

--- a/src/pages/EditChecklistPage.tsx
+++ b/src/pages/EditChecklistPage.tsx
@@ -44,12 +44,12 @@ export default function EditChecklistPage() {
   const navigate = useNavigate();
   const { checklistId } = useParams<{ checklistId: string }>();
   const { user } = useAuth();
-  const { subscription, getAccessStatus } = useSubscription();
+  const { loading, getAccessStatus } = useSubscription();
   const { checklists, updateChecklist } = useChecklists();
   const { steps: checklistSteps, createStep, updateStep, deleteStep, reorderSteps } = useChecklistSteps(checklistId || null);
   const accessStatus = getAccessStatus();
-  
-  const [loading, setLoading] = useState(false);
+
+  const [saving, setSaving] = useState(false);
   const [editingStepIndex, setEditingStepIndex] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -69,10 +69,10 @@ export default function EditChecklistPage() {
 
   // Redirect to dashboard if no active subscription
   useEffect(() => {
-    if (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted) {
+    if (!loading && (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted)) {
       navigate('/dashboard');
     }
-  }, [accessStatus, navigate]);
+  }, [loading, accessStatus, navigate]);
 
   useEffect(() => {
     if (!checklistId) {
@@ -197,7 +197,7 @@ export default function EditChecklistPage() {
       return;
     }
 
-    setLoading(true);
+    setSaving(true);
     setError(null);
     setSuccess(null);
 
@@ -212,7 +212,7 @@ export default function EditChecklistPage() {
         setError('Failed to update checklist');
       }
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   };
 
@@ -569,10 +569,10 @@ export default function EditChecklistPage() {
             </button>
             <button
               onClick={handleSave}
-              disabled={loading || !formData.title.trim()}
+              disabled={saving || !formData.title.trim()}
               className="bg-emerald-500 hover:bg-emerald-600 text-white px-8 py-3 rounded-lg font-semibold transition-colors flex items-center disabled:opacity-50 font-sans"
             >
-              {loading ? (
+              {saving ? (
                 <>
                   <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2"></div>
                   Saving...

--- a/src/pages/SubmissionsPage.tsx
+++ b/src/pages/SubmissionsPage.tsx
@@ -34,9 +34,9 @@ import {
 
 export default function SubmissionsPage() {
   const { user } = useAuth();
-  const { subscription, getAccessStatus } = useSubscription();
+  const { loading, getAccessStatus } = useSubscription();
   const navigate = useNavigate();
-  const { sessions, loading, error, deleteSession, getSessionStats, getSessionProgress } = useCustomerSessions();
+  const { sessions, loading: sessionsLoading, error, deleteSession, getSessionStats, getSessionProgress } = useCustomerSessions();
   const { messages, showSuccess, showError, showWarning, dismissToast } = useToast();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [copiedSessionId, setCopiedSessionId] = useState<string | null>(null);
@@ -63,10 +63,10 @@ export default function SubmissionsPage() {
 
   // Redirect to dashboard if no active subscription
   useEffect(() => {
-    if (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted) {
+    if (!loading && (!accessStatus.hasAccess || accessStatus.shouldRedirectToGetStarted)) {
       navigate('/dashboard');
     }
-  }, [accessStatus, navigate]);
+  }, [loading, accessStatus, navigate]);
 
   // Track progress for each session
   const [sessionProgress, setSessionProgress] = useState<Record<string, number>>({});
@@ -481,7 +481,7 @@ export default function SubmissionsPage() {
     });
   };
 
-  if (loading) {
+  if (sessionsLoading) {
     return (
       <div className="pt-20 min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">


### PR DESCRIPTION
## Summary
- Add `loading` state from `useSubscription` to pages that check access status
- Only redirect to dashboard after subscription info loads
- Rename local loading flags to avoid clashes with subscription loading

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c45326a884832a99586e4534bb20d9