### PR TITLE
Fix Settings page redirect by using single subscription hook

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,9 +8,9 @@ import SettingsSkeleton from '../components/SettingsSkeleton';
 
 export default function SettingsPage() {
   const { user } = useAuth();
-  const { subscription, loading } = useSubscription();
+  // Use a single subscription hook instance to avoid inconsistent state
+  const { subscription, loading, getAccessStatus } = useSubscription();
   const navigate = useNavigate();
-  const { getAccessStatus } = useSubscription();
 
   const accessStatus = getAccessStatus();
 


### PR DESCRIPTION
## Summary
- Use a single `useSubscription` instance in SettingsPage to prevent premature redirects that hid the page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c458e8e628832a82d1647e9c28b4de